### PR TITLE
implements auth based on viral loop campaign

### DIFF
--- a/pages/api/login/index.ts
+++ b/pages/api/login/index.ts
@@ -2,6 +2,47 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { calcAuthCookie } from 'lib/auth'
 import { fetchURL } from 'lib/fetch'
 
+const onViralLoops = async (uri: string, email: string): Promise<any> => {
+  const apiToken = process.env.VIRAL_LOOP_SECRET_TOKEN || ''
+  const body = { participants: [{ email }] }
+  const url = `https://app.viral-loops.com/api/v3/campaign/participant/${uri}`
+
+  const res = await fetch(url, {
+    body: JSON.stringify(body),
+    headers: {
+      apiToken,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  })
+
+  if (!res.ok) {
+    const errorMessage = await res.text()
+    console.log(`${res.statusText}: ${errorMessage}`)
+    return
+  }
+
+  return await res.json()
+}
+
+const getUserRank = async (email: string) => {
+  const publicToken = process.env.VIRAL_LOOP_PUBLIC_TOKEN
+  const url =
+    'https://app.viral-loops.com/api/v3/campaign/participant/order?' +
+    `publicToken=${publicToken}&` +
+    `email=${email}`
+  const user = await fetchURL(url)
+  return user.rank
+}
+
+const flagUser = async (email: string) => await onViralLoops('flag', email)
+
+const userIsFlagged = async (email: string) => {
+  const data = await onViralLoops('query', email)
+  return data?.data[0]?.user?.excluded
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -12,23 +53,25 @@ export default async function handler(
   const email = req.body
   const vipList = JSON.parse(process.env.VIP_LIST || '[]')
 
+  // on success, return cookie value to be set client side
   const success = () => res.status(200).json(calcAuthCookie(email))
+  const failure = () => res.status(401).end()
 
+  // if user is on vip list, let him in
   if (vipList.includes(email)) return success()
 
-  const maxOrder = process.env.VIRAL_LOOP_MAX_ORDER
-  const publicToken = process.env.VIRAL_LOOP_PUBLIC_TOKEN
+  // if user was previouslly flagged, let him in
+  if (await userIsFlagged(email)) return success()
 
-  const url =
-    'https://app.viral-loops.com/api/v3/campaign/participant/order?' +
-    `publicToken=${publicToken}&` +
-    `email=${email}`
+  // else, check if user has rank <= max rank defined on env
+  // if so, flag him and he will always be allowed to enter
+  const maxRank = process.env.VIRAL_LOOP_MAX_RANK || -1
+  const userRank = (await getUserRank(email)) || 0
+  if (userRank <= maxRank) {
+    await flagUser(email)
+    return success()
+  }
 
-  const data = await fetchURL(url)
-
-  // if valid email, return cookie value to be set client side
-  if (maxOrder && data.order <= maxOrder) return success()
-
-  // email not in vip list, return 401
-  return res.status(401).end()
+  // email not allowed, return 401
+  return failure()
 }


### PR DESCRIPTION
Closes #11 

Allows access to the app to email addresses with order of sign up less or equal to VIRAL_LOOP_MAX_ORDER.

Requires two new environment variables:

- VIRAL_LOOP_MAX_ORDER=10
- VIRAL_LOOP_PUBLIC_TOKEN=\<aka Campaign ID\>

The following environment variable can be removed:
- VIP_LIST

@miyo-fuji please review
