### PR TITLE
Bug fix contracts assets value

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -149,5 +149,5 @@ export const findAssetByTicker = async (ticker: string): Promise<Asset> => {
 
 export const getBTCvalue = async (): Promise<number> => {
   const data = await fetchURL(oracleURL)
-  return Number(data?.lastPrice)
+  return data ? Number(data.lastPrice) : 0
 }


### PR DESCRIPTION
Bug fix where contracts were not having fresh info for collateral and synthetic.

In the case of the oracle down, contracts should have collateral value unknown (or 0) which means the ratio state should be Unknown, and not Safe or Critical as they were being show when bitfinex was down.

The problem was that contracts were using collateral and synthetic values from the moment they were created, without updating, which is wrong.

@miyo-fuji please review