### PR TITLE
change electrum url

### DIFF
--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -7,9 +7,9 @@ export const electrumURL = (network: NetworkString) => {
     case 'regtest':
       return 'http://localhost:3001' // TODO
     case 'testnet':
-      return 'wss://esplora.blockstream.com/liquidtestnet/electrum-websocket/api'
+      return 'wss://blockstream.info/liquidtestnet/electrum-websocket/api'
     default:
-      return 'wss://esplora.blockstream.com/liquid/electrum-websocket/api'
+      return 'wss://blockstream.info/liquid/electrum-websocket/api'
   }
 }
 


### PR DESCRIPTION
This PR changes `esplora.blockstream.com` to `blockstream.info`

@miyo-fuji please review