### PR TITLE
Fixes checking for contract confirmation

### DIFF
--- a/components/providers/contracts.tsx
+++ b/components/providers/contracts.tsx
@@ -120,6 +120,11 @@ export const ContractsProvider = ({ children }: ContractsProviderProps) => {
 
     // check if a contract is confirmed by its transaction history
     // https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-get-history
+    // In summary:
+    //   unknown => hist.length == 0
+    //   mempool => hist.length == 1 && hist[0].height == 0
+    //   confirm => hist.length > 0 && hist[0].height != 0
+    //   spent   => hist.length == 2
     const notConfirmed = async (contract: Contract) => {
       const [hist] = await chainSource.fetchHistories([
         address.toOutputScript(


### PR DESCRIPTION
So it seems this is NOT the correct way to check if a tx is confirmed:

```
const [hist] = await chainSource.fetchHistories([
  address.toOutputScript(
    await getContractCovenantAddress(contract, network),
  ),
])
if (hist.length === 0) continue
```

The problem is, if the tx is on the mempool, it will return an entry on hist, with attribute height equal to 0.

In summary:

  unknown => hist.length == 0
  mempool => hist.length == 1 && hist[0].height == 0
  confirm => hist.length > 0 && hist[0].height != 0
  spent   => hist.length == 2

@tiero please review