### PR TITLE
Start borrow on 200%

### DIFF
--- a/components/borrow/index.tsx
+++ b/components/borrow/index.tsx
@@ -22,7 +22,7 @@ const Borrow = ({ offer, oracles }: BorrowProps) => {
   const [ratio, setRatio] = useState(startingRatio)
 
   const minRatio = offer.collateral.ratio || minBorrowRatio
-  const priceLevel = getContractPriceLevel(offer.collateral, minRatio)
+  const priceLevel = getContractPriceLevel(offer.collateral, startingRatio)
 
   const [contract, setContract] = useState<Contract>({ ...offer, priceLevel })
 

--- a/components/borrow/index.tsx
+++ b/components/borrow/index.tsx
@@ -17,7 +17,9 @@ interface BorrowProps {
 
 const Borrow = ({ offer, oracles }: BorrowProps) => {
   const { newContract } = useContext(ContractsContext)
-  const [ratio, setRatio] = useState(offer.collateral.ratio || 0)
+
+  const startingRatio = offer.collateral.ratio ? offer.collateral.ratio + 50 : 0
+  const [ratio, setRatio] = useState(startingRatio)
 
   const minRatio = offer.collateral.ratio || minBorrowRatio
   const priceLevel = getContractPriceLevel(offer.collateral, minRatio)


### PR DESCRIPTION
On borrow start ratio on safe level (200%) instead of liquidation level (150%)

@tiero please review