### PR TITLE
Normalize contract params types

### DIFF
--- a/components/providers/wallet.tsx
+++ b/components/providers/wallet.tsx
@@ -89,6 +89,7 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
     }
   }, [connected, marina])
 
+  // when network changes, connect to respective electrum server
   useEffect(() => {
     if (chainSource.network !== network) {
       chainSource

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -11,7 +11,7 @@ import {
 import { addActivity, removeActivities } from './activities'
 import { getIonioInstance } from './covenant'
 import { isIonioScriptDetails, NetworkString, Utxo } from 'marina-provider'
-import { hexLEToNumber, hexLEToString } from './utils'
+import { hex64LEToNumber } from './utils'
 import { ChainSource } from './chainsource.port'
 import { address, Transaction } from 'liquidjs-lib'
 
@@ -81,14 +81,14 @@ export const coinToContract = async (
         borrowerPublicKey: params[2] as string,
         oraclePublicKey: params[3] as string,
         issuerPublicKey: params[4] as string,
-        priceLevel: hexLEToString(params[5] as string),
-        setupTimestamp: hexLEToString(params[6] as string),
+        priceLevel: params[5] as string,
+        setupTimestamp: params[6] as string,
       },
-      createdAt: hexLEToNumber(params[6] as string),
+      createdAt: hex64LEToNumber(params[6] as string),
       network: await getNetwork(),
       oracles: [oracle.id],
       payout: defaultPayout,
-      priceLevel: hexLEToNumber(params[5] as string),
+      priceLevel: hex64LEToNumber(params[5] as string),
       synthetic: {
         ...synthetic,
         quantity: params[1] as number,

--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -9,7 +9,7 @@ import {
   minDustLimit,
   oraclePubKey,
 } from 'lib/constants'
-import { numberToHexEncodedUint64LE, numberToUint64LE } from './utils'
+import { numberToHex64LE, hex64LEToBase64LE } from './utils'
 import {
   payments,
   address,
@@ -67,8 +67,8 @@ export async function getIonioInstance(
     params.borrowerPublicKey,
     params.oraclePublicKey,
     params.issuerPublicKey,
-    numberToHexEncodedUint64LE(Number(params.priceLevel)),
-    numberToHexEncodedUint64LE(Number(params.setupTimestamp)),
+    params.priceLevel,
+    params.setupTimestamp,
   ]
 
   return new IonioContract(
@@ -97,26 +97,15 @@ async function getCovenantOutput(contract: Contract): Promise<{
     borrowAmount: contract.synthetic.quantity,
     oraclePublicKey: `0x${oraclePk.slice(1).toString('hex')}`,
     issuerPublicKey: `0x${issuerPk.slice(1).toString('hex')}`,
-    priceLevel: numberToUint64LE(contract.priceLevel || 0).toString('base64'),
-    setupTimestamp: numberToUint64LE(timestamp).toString('base64'),
+    priceLevel: numberToHex64LE(contract.priceLevel || 0),
+    setupTimestamp: numberToHex64LE(timestamp),
   }
 
   // get needed addresses
   await marina.useAccount(marinaFujiAccountID)
   const covenantAddress = await marina.getNextAddress({
     artifact: artifact as Artifact,
-    // Marina needs to have the priceLevel and setupTimestamp params as Buffer
-    args: {
-      ...contractParams,
-      priceLevel: `0x${Buffer.from(
-        contractParams.priceLevel,
-        'base64',
-      ).toString('hex')}`,
-      setupTimestamp: `0x${Buffer.from(
-        contractParams.setupTimestamp,
-        'base64',
-      ).toString('hex')}`,
-    },
+    args: contractParams,
   })
 
   // switch back to marina main account
@@ -350,8 +339,8 @@ export async function proposeBorrowContract({
       issuerPublicKey,
       oraclePublicKey,
       borrowerPublicKey,
-      priceLevel,
-      setupTimestamp,
+      priceLevel: hex64LEToBase64LE(priceLevel),
+      setupTimestamp: hex64LEToBase64LE(setupTimestamp),
     },
     blindersOfCollateralInputs,
     partialTransaction: pset.toBase64(),
@@ -782,8 +771,8 @@ export async function proposeTopupContract({
       issuerPublicKey,
       oraclePublicKey,
       borrowerPublicKey,
-      priceLevel,
-      setupTimestamp,
+      priceLevel: hex64LEToBase64LE(priceLevel),
+      setupTimestamp: hex64LEToBase64LE(setupTimestamp),
     },
     blindersOfCollateralInputs,
     blindersOfSynthInputs,

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -31,13 +31,7 @@ import {
   getInvoiceExpireDate,
   ReverseSwap,
 } from 'lib/swaps'
-import {
-  openModal,
-  extractError,
-  retry,
-  sleep,
-  bufferBase64LEToString,
-} from 'lib/utils'
+import { openModal, extractError, retry, sleep } from 'lib/utils'
 import {
   BIP174SigningData,
   Pset,
@@ -207,11 +201,7 @@ const BorrowParams: NextPage = () => {
 
     // add contractParams to contract
     const { contractParams } = preparedTx
-    newContract.contractParams = {
-      ...contractParams,
-      priceLevel: bufferBase64LEToString(contractParams.priceLevel),
-      setupTimestamp: bufferBase64LEToString(contractParams.setupTimestamp),
-    }
+    newContract.contractParams = { ...contractParams }
 
     // add additional fields to contract and save to storage
     // note: save before mark as confirmed (next code block)

--- a/pages/contracts/[txid]/topup/lightning.tsx
+++ b/pages/contracts/[txid]/topup/lightning.tsx
@@ -7,13 +7,7 @@ import InvoiceDepositModal from 'components/modals/invoiceDeposit'
 import { WalletContext } from 'components/providers/wallet'
 import { ModalIds, ModalStages } from 'components/modals/modal'
 import SomeError from 'components/layout/error'
-import {
-  bufferBase64LEToString,
-  extractError,
-  openModal,
-  retry,
-  sleep,
-} from 'lib/utils'
+import { extractError, openModal, retry, sleep } from 'lib/utils'
 import ECPairFactory from 'ecpair'
 import * as ecc from 'tiny-secp256k1'
 import { randomBytes } from 'crypto'
@@ -232,11 +226,7 @@ const ContractTopupLightning: NextPage = () => {
 
         // add contractParams to contract
         const { contractParams } = preparedTx
-        newContract.contractParams = {
-          ...contractParams,
-          priceLevel: bufferBase64LEToString(contractParams.priceLevel),
-          setupTimestamp: bufferBase64LEToString(contractParams.setupTimestamp),
-        }
+        newContract.contractParams = { ...contractParams }
 
         // add additional fields to contract and save to storage
         // note: save before mark as confirmed (next code block)

--- a/pages/contracts/[txid]/topup/liquid.tsx
+++ b/pages/contracts/[txid]/topup/liquid.tsx
@@ -16,12 +16,7 @@ import {
   prepareTopupTx,
   proposeTopupContract,
 } from 'lib/covenant'
-import {
-  openModal,
-  extractError,
-  retry,
-  bufferBase64LEToString,
-} from 'lib/utils'
+import { openModal, extractError, retry } from 'lib/utils'
 import EnablersLiquid from 'components/enablers/liquid'
 import MarinaDepositModal from 'components/modals/marinaDeposit'
 import { Outcome } from 'lib/types'
@@ -117,11 +112,7 @@ const ContractTopupLiquid: NextPage = () => {
 
       // add contractParams to contract
       const { contractParams } = preparedTx
-      newContract.contractParams = {
-        ...contractParams,
-        priceLevel: bufferBase64LEToString(contractParams.priceLevel),
-        setupTimestamp: bufferBase64LEToString(contractParams.setupTimestamp),
-      }
+      newContract.contractParams = { ...contractParams }
 
       // add additional fields to contract and save to storage
       // note: save before mark as confirmed (next code block)


### PR DESCRIPTION
This PR

- normalize encoding of contractParams priceLevel and setupTimestamp
  - values go to alpha factory in base64 64 bytes LE (Little Endian)
  - are used by Marina and Ionio encoded in hex 64 bytes LE
  - we need to extract the numeric values to recreate contracts
    from marina coins in syncContractsWithMarina and coinToContract
- strategy is allways have it in hex64LE and derive from there
- stores contractParams priceLevel and setupTimestamp in hex64LE
- migrates old contracts on storage to use encoding hex64LE

Tested.

@tiero please review