### PR TITLE
Several bug fixes

### DIFF
--- a/components/assets/list.tsx
+++ b/components/assets/list.tsx
@@ -3,12 +3,10 @@ import { Asset } from 'lib/types'
 import SomeError from 'components/layout/error'
 import AssetRow from './row'
 import Spinner from 'components/spinner'
-import { ContractsContext } from 'components/providers/contracts'
 import { ConfigContext } from 'components/providers/config'
 
 const AssetsList = () => {
-  const { config } = useContext(ConfigContext)
-  const { loading } = useContext(ContractsContext)
+  const { config, loading } = useContext(ConfigContext)
 
   const [filteredAssets, setFilteredAssets] = useState<Asset[]>()
 

--- a/components/borrow/form.tsx
+++ b/components/borrow/form.tsx
@@ -1,10 +1,6 @@
 import Oracles from 'components/oracles'
-import { Contract, Oracle } from 'lib/types'
-import {
-  getCollateralQuantity,
-  getContractPayoutAmount,
-  getContractPriceLevel,
-} from 'lib/contracts'
+import { Contract } from 'lib/types'
+import { getCollateralQuantity, getContractPriceLevel } from 'lib/contracts'
 import Collateral from './collateral'
 import Ratio from './ratio'
 import Synthetic from './synthetic'
@@ -35,8 +31,7 @@ const BorrowForm = ({
     const synthetic = { ...contract.synthetic, quantity }
     quantity = getCollateralQuantity({ ...contract, synthetic }, ratio)
     const collateral = { ...contract.collateral, quantity }
-    const payoutAmount = getContractPayoutAmount(contract, quantity)
-    setContract({ ...contract, collateral, synthetic, payoutAmount })
+    setContract({ ...contract, collateral, synthetic })
   }
 
   const setContractRatio = (newRatio: number) => {
@@ -45,8 +40,7 @@ const BorrowForm = ({
     const quantity = getCollateralQuantity(contract, ratio)
     const collateral = { ...contract.collateral, quantity }
     const priceLevel = getContractPriceLevel(contract.collateral, ratio)
-    const payoutAmount = getContractPayoutAmount(contract, quantity)
-    setContract({ ...contract, collateral, priceLevel, payoutAmount })
+    setContract({ ...contract, collateral, priceLevel })
   }
 
   return (

--- a/components/borrow/index.tsx
+++ b/components/borrow/index.tsx
@@ -22,7 +22,7 @@ const Borrow = ({ offer }: BorrowProps) => {
   const { network, xPubKey } = useContext(WalletContext)
   const { newContract } = useContext(ContractsContext)
 
-  const { collateral, oracles, payout, synthetic } = offer
+  const { collateral, oracles, synthetic } = offer
 
   const startingRatio = collateral.minCollateralRatio
     ? collateral.minCollateralRatio + 50
@@ -37,7 +37,6 @@ const Borrow = ({ offer }: BorrowProps) => {
     expirationDate: getContractExpirationDate(),
     network,
     oracles,
-    payout,
     synthetic,
     priceLevel,
     xPubKey,

--- a/components/borrow/info.tsx
+++ b/components/borrow/info.tsx
@@ -1,4 +1,3 @@
-import { getContractPayoutAmount } from 'lib/contracts'
 import { prettyExpirationDate, prettyNumber, prettyQuantity } from 'lib/pretty'
 import { Contract } from 'lib/types'
 import { fromSatoshis } from 'lib/utils'
@@ -9,7 +8,6 @@ interface BorrowInfoProps {
 
 const BorrowInfo = ({ contract }: BorrowInfoProps) => {
   const { collateral, priceLevel, synthetic } = contract
-  const payoutAmount = getContractPayoutAmount(contract)
   return (
     <div className="is-box has-pink-border is-size-7">
       <div className="level">
@@ -20,7 +18,6 @@ const BorrowInfo = ({ contract }: BorrowInfoProps) => {
               <p>Current reference price</p>
               <p>Liquidation price level</p>
               <p>Collateral amount</p>
-              <p>Minting fee</p>
               <p>Expiration date</p>
             </div>
           </div>
@@ -38,13 +35,6 @@ const BorrowInfo = ({ contract }: BorrowInfoProps) => {
                 {prettyQuantity(
                   collateral.quantity,
                   collateral.precision,
-                  collateral.precision,
-                )}{' '}
-                {collateral.ticker}
-              </p>
-              <p>
-                {prettyNumber(
-                  fromSatoshis(payoutAmount, collateral.precision),
                   collateral.precision,
                 )}{' '}
                 {collateral.ticker}

--- a/components/investments/index.tsx
+++ b/components/investments/index.tsx
@@ -13,9 +13,11 @@ const Investments = () => {
   const [investments, setInvestments] = useState<Investment[]>()
 
   useEffect(() => {
-    fetchInvestments(network).then((data) => {
-      setInvestments(data)
-    })
+    if (network) {
+      fetchInvestments(network).then((data) => {
+        setInvestments(data)
+      })
+    }
   }, [network])
 
   if (loading) return <Spinner />

--- a/components/investments/list.tsx
+++ b/components/investments/list.tsx
@@ -13,9 +13,11 @@ const InvestmentsList = () => {
   const [investments, setInvestments] = useState<Investment[]>()
 
   useEffect(() => {
-    fetchInvestments(network).then((data) => {
-      setInvestments(data)
-    })
+    if (network) {
+      fetchInvestments(network).then((data) => {
+        setInvestments(data)
+      })
+    }
   }, [network])
 
   if (loading) return <Spinner />

--- a/components/notifications/index.tsx
+++ b/components/notifications/index.tsx
@@ -44,7 +44,7 @@ const Notifications = ({
 
   const { assets } = config
 
-  const { collateral, oracles, payoutAmount, synthetic } = contract
+  const { collateral, oracles, synthetic } = contract
   const spendQuantity =
     typeof topup === 'undefined' ? collateral.quantity : topup
 
@@ -82,10 +82,6 @@ const Notifications = ({
   useEffect(() => {
     setNotEnoughOracles(oracles?.length === 0)
   }, [oracles])
-
-  useEffect(() => {
-    if (payoutAmount) setBelowDustLimit(payoutAmount < minDustLimit)
-  }, [payoutAmount])
 
   return (
     <>

--- a/components/providers/config.tsx
+++ b/components/providers/config.tsx
@@ -21,6 +21,7 @@ import { ModalIds } from 'components/modals/modal'
 
 interface ConfigContextProps {
   config: Config
+  loading: boolean
   reloadConfig: () => void
 }
 
@@ -28,6 +29,7 @@ const emptyConfig = { assets: [], offers: [], oracles: [] }
 
 export const ConfigContext = createContext<ConfigContextProps>({
   config: emptyConfig,
+  loading: true,
   reloadConfig: () => {},
 })
 
@@ -35,10 +37,14 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useContext(WalletContext)
 
   const [config, setConfig] = useState<Config>(emptyConfig)
+  const [loading, setLoading] = useState(true)
 
   const reloadConfig = async () => {
     // return if network not defined
-    if (!network) return
+    if (!network) {
+      setLoading(false)
+      return
+    }
 
     // fetch config from factory
     const config: ConfigResponse = await fetchConfig(network)
@@ -69,6 +75,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     )
 
     setConfig({ assets, offers, oracles })
+    setLoading(false)
   }
 
   useEffect(() => {
@@ -77,7 +84,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
   }, [network])
 
   return (
-    <ConfigContext.Provider value={{ config, reloadConfig }}>
+    <ConfigContext.Provider value={{ config, loading, reloadConfig }}>
       {children}
     </ConfigContext.Provider>
   )

--- a/components/providers/config.tsx
+++ b/components/providers/config.tsx
@@ -21,24 +21,23 @@ import { ModalIds } from 'components/modals/modal'
 
 interface ConfigContextProps {
   config: Config
+  reloadConfig: () => void
 }
 
 const emptyConfig = { assets: [], offers: [], oracles: [] }
 
 export const ConfigContext = createContext<ConfigContextProps>({
   config: emptyConfig,
+  reloadConfig: () => {},
 })
 
-interface ConfigProviderProps {
-  children: ReactNode
-}
-
-export const ConfigProvider = ({ children }: ConfigProviderProps) => {
+export const ConfigProvider = ({ children }: { children: ReactNode }) => {
   const { network } = useContext(WalletContext)
 
   const [config, setConfig] = useState<Config>(emptyConfig)
 
   const reloadConfig = async () => {
+    // return if network not defined
     if (!network) return
 
     // fetch config from factory
@@ -48,7 +47,7 @@ export const ConfigProvider = ({ children }: ConfigProviderProps) => {
     // populate oracles with name
     const oracles = config.oracles.map((oracle) => populateOracle(oracle))
 
-    // populate assets with all different attributes
+    // populate assets with additional attributes
     const assets = config.assets
       .map((asset) => populateAsset(asset))
       .concat(getLBTC(network))
@@ -78,7 +77,7 @@ export const ConfigProvider = ({ children }: ConfigProviderProps) => {
   }, [network])
 
   return (
-    <ConfigContext.Provider value={{ config }}>
+    <ConfigContext.Provider value={{ config, reloadConfig }}>
       {children}
     </ConfigContext.Provider>
   )

--- a/components/providers/config.tsx
+++ b/components/providers/config.tsx
@@ -34,11 +34,13 @@ interface ConfigProviderProps {
 }
 
 export const ConfigProvider = ({ children }: ConfigProviderProps) => {
-  const { network, warmingUp } = useContext(WalletContext)
+  const { network } = useContext(WalletContext)
 
   const [config, setConfig] = useState<Config>(emptyConfig)
 
   const reloadConfig = async () => {
+    if (!network) return
+
     // fetch config from factory
     const config: ConfigResponse = await fetchConfig(network)
     if (!config) return
@@ -71,9 +73,9 @@ export const ConfigProvider = ({ children }: ConfigProviderProps) => {
   }
 
   useEffect(() => {
-    if (!warmingUp) reloadConfig()
+    if (network) reloadConfig()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [network, warmingUp])
+  }, [network])
 
   return (
     <ConfigContext.Provider value={{ config }}>

--- a/components/providers/contracts.tsx
+++ b/components/providers/contracts.tsx
@@ -92,7 +92,6 @@ export const ContractsProvider = ({ children }: ContractsProviderProps) => {
   // setLoading(false) is there only to remove spinner on first render
   const reloadContracts = async () => {
     if (connected && network) {
-      setLoading(true)
       await checkContractsStatus()
       setContracts(await getContracts(assets, network))
       setActivities(await getActivities())

--- a/components/providers/contracts.tsx
+++ b/components/providers/contracts.tsx
@@ -64,7 +64,7 @@ interface ContractsProviderProps {
 export const ContractsProvider = ({ children }: ContractsProviderProps) => {
   const { chainSource, connected, marina, network, xPubKey } =
     useContext(WalletContext)
-  const { config } = useContext(ConfigContext)
+  const { config, reloadConfig } = useContext(ConfigContext)
 
   const [activities, setActivities] = useState<Activity[]>([])
   const [contracts, setContracts] = useState<Contract[]>([])
@@ -75,11 +75,12 @@ export const ContractsProvider = ({ children }: ContractsProviderProps) => {
   const { assets } = config
 
   // save first time app was run
-  const firstRun = useRef(Date.now())
+  const lastReload = useRef(Date.now())
 
   const reloadAndMarkLastReload = () => {
-    firstRun.current = Date.now()
+    lastReload.current = Date.now()
     reloadContracts()
+    reloadConfig()
   }
 
   const resetContracts = () => {
@@ -214,7 +215,8 @@ export const ContractsProvider = ({ children }: ContractsProviderProps) => {
   const setMarinaListener = () => {
     // try to avoid first burst of events sent by marina (on reload)
     const okToReload = (accountID: string) =>
-      accountID === marinaFujiAccountID && Date.now() - firstRun.current > 30000
+      accountID === marinaFujiAccountID &&
+      Date.now() - lastReload.current > 30000
     // add event listeners
     if (connected && marina && xPubKey) {
       const listenerFunction = async ({

--- a/components/providers/contracts.tsx
+++ b/components/providers/contracts.tsx
@@ -260,7 +260,7 @@ export const ContractsProvider = ({ children }: ContractsProviderProps) => {
     }
     runOnAssetsChange()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assets])
+  }, [assets, connected])
 
   return (
     <ContractsContext.Provider

--- a/components/providers/wallet.tsx
+++ b/components/providers/wallet.tsx
@@ -15,11 +15,10 @@ interface WalletContextProps {
   chainSource: ChainSource
   connected: boolean
   marina: MarinaProvider | undefined
-  network: NetworkString
+  network: NetworkString | undefined
   setConnected: (arg0: boolean) => void
   updateBalances: () => void
   xPubKey: string
-  warmingUp: boolean
 }
 
 export const WalletContext = createContext<WalletContextProps>({
@@ -27,11 +26,10 @@ export const WalletContext = createContext<WalletContextProps>({
   chainSource: new WsElectrumChainSource(defaultNetwork),
   connected: false,
   marina: undefined,
-  network: defaultNetwork,
+  network: undefined,
   setConnected: () => {},
   updateBalances: () => {},
   xPubKey: '',
-  warmingUp: true,
 })
 
 interface WalletProviderProps {
@@ -44,9 +42,8 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
   )
   const [connected, setConnected] = useState(false)
   const [marina, setMarina] = useState<MarinaProvider>()
-  const [network, setNetwork] = useState<NetworkString>(defaultNetwork)
+  const [network, setNetwork] = useState<NetworkString>()
   const [xPubKey, setXPubKey] = useState('')
-  const [warmingUp, setWarmingUp] = useState(true)
 
   const updateBalances = async () => setBalances(await getBalances())
   const updateNetwork = async () => setNetwork(await getNetwork())
@@ -54,10 +51,7 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
 
   // get marina provider
   useEffect(() => {
-    getMarinaProvider().then((marinaProvider) => {
-      if (!marinaProvider) setWarmingUp(false)
-      else setMarina(marinaProvider)
-    })
+    getMarinaProvider().then((marinaProvider) => setMarina(marinaProvider))
   }, [])
 
   // update connected state
@@ -71,7 +65,7 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
 
   // add event listeners for enable and disable (aka connected)
   useEffect(() => {
-    if (marina) {
+    if (marina && network) {
       const onDisabledId = marina.on('DISABLED', ({ data }) => {
         if (data.network === network) setConnected(false)
       })
@@ -89,14 +83,9 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
   useEffect(() => {
     if (connected && marina) {
       updateNetwork()
-      // give time for network change to propagate across components
-      // if user has marina on 'testnet' and app default is 'liquid'
-      // a race condition could ocurr
-      sleep(2000).then(() => setWarmingUp(false))
       const id = marina.on('NETWORK', updateNetwork)
       return () => marina.off(id)
     }
-    if (!connected) setWarmingUp(false)
   }, [connected, marina])
 
   // when network changes, connect to respective electrum server
@@ -147,7 +136,6 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
         setConnected,
         updateBalances,
         xPubKey,
-        warmingUp,
       }}
     >
       {children}

--- a/components/providers/wallet.tsx
+++ b/components/providers/wallet.tsx
@@ -8,7 +8,6 @@ import {
 import { Balance, MarinaProvider, NetworkString } from 'marina-provider'
 import { defaultNetwork } from 'lib/constants'
 import { ChainSource, WsElectrumChainSource } from 'lib/chainsource.port'
-import { sleep } from 'lib/utils'
 
 interface WalletContextProps {
   balances: Balance[]

--- a/components/providers/wallet.tsx
+++ b/components/providers/wallet.tsx
@@ -51,7 +51,10 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
 
   // get marina provider
   useEffect(() => {
-    getMarinaProvider().then((marinaProvider) => setMarina(marinaProvider))
+    getMarinaProvider().then((marinaProvider) => {
+      setMarina(marinaProvider)
+      updateNetwork()
+    })
   }, [])
 
   // update connected state
@@ -82,7 +85,6 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
   // update network and add event listener
   useEffect(() => {
     if (connected && marina) {
-      updateNetwork()
       const id = marina.on('NETWORK', updateNetwork)
       return () => marina.off(id)
     }

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -11,6 +11,7 @@ import { getContractRatio } from 'lib/contracts'
 import { SomethingWentWrong } from 'components/layout/error'
 import { useContext } from 'react'
 import { ContractsContext } from 'components/providers/contracts'
+import { ConfigContext } from 'components/providers/config'
 
 interface SuccessProps {
   contract: Contract
@@ -19,12 +20,13 @@ interface SuccessProps {
 }
 
 const Success = ({ contract, task, txid }: SuccessProps) => {
-  const { reloadContracts, resetContracts } = useContext(ContractsContext)
+  const { reloadConfig } = useContext(ConfigContext)
+  const { resetContracts } = useContext(ContractsContext)
 
   const handleClick = () => {
     closeAllModals()
     resetContracts()
-    reloadContracts()
+    reloadConfig()
   }
 
   // Twitter message

--- a/components/stocks/list.tsx
+++ b/components/stocks/list.tsx
@@ -13,9 +13,11 @@ const StocksList = () => {
   const [stocks, setStocks] = useState<Stock[]>()
 
   useEffect(() => {
-    fetchStocks(network).then((data) => {
-      setStocks(data)
-    })
+    if (network) {
+      fetchStocks(network).then((data) => {
+        setStocks(data)
+      })
+    }
   }, [network])
 
   if (loading) return <Spinner />

--- a/components/topup/index.tsx
+++ b/components/topup/index.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 import {
   getCollateralQuantity,
-  getContractPayoutAmount,
   getContractPriceLevel,
   getContractRatio,
 } from 'lib/contracts'
@@ -31,8 +30,7 @@ const Topup = () => {
       const quantity = getCollateralQuantity(newContract, ratio)
       const collateral = { ...newContract.collateral, quantity }
       const priceLevel = getContractPriceLevel(newContract.collateral, ratio)
-      const payoutAmount = getContractPayoutAmount(newContract, quantity)
-      setNewContract({ ...newContract, collateral, priceLevel, payoutAmount })
+      setNewContract({ ...newContract, collateral, priceLevel })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ratio])

--- a/components/topup/info.tsx
+++ b/components/topup/info.tsx
@@ -1,4 +1,3 @@
-import { getContractPayoutAmount } from 'lib/contracts'
 import { prettyExpirationDate, prettyNumber, prettyQuantity } from 'lib/pretty'
 import { Contract } from 'lib/types'
 import { fromSatoshis } from 'lib/utils'
@@ -11,7 +10,6 @@ interface TopupInfoProps {
 const TopupInfo = ({ newContract, oldContract }: TopupInfoProps) => {
   const { collateral, synthetic } = oldContract
   const newPriceLevel = newContract.priceLevel
-  const newPayoutAmount = getContractPayoutAmount(newContract)
   return (
     <div className="is-box has-pink-border is-size-7">
       <div className="level">
@@ -22,7 +20,6 @@ const TopupInfo = ({ newContract, oldContract }: TopupInfoProps) => {
               <p>Current reference price</p>
               <p>Liquidation price level</p>
               <p>Collateral amount</p>
-              <p>Minting fee</p>
               <p>Expiration date</p>
             </div>
           </div>
@@ -40,14 +37,6 @@ const TopupInfo = ({ newContract, oldContract }: TopupInfoProps) => {
                 {prettyQuantity(
                   newContract.collateral.quantity,
                   newContract.collateral.precision,
-                )}{' '}
-                {collateral.ticker}
-              </p>
-              <p>
-                {prettyNumber(
-                  fromSatoshis(newPayoutAmount, collateral.precision),
-                  0,
-                  collateral.precision,
                 )}{' '}
                 {collateral.ticker}
               </p>

--- a/lib/boltz.ts
+++ b/lib/boltz.ts
@@ -24,14 +24,18 @@ export type ReverseSubmarineSwapRequest = {
 }
 
 export type SubmarineSwapResponse = {
-  address: string
-  redeemScript: string
   acceptZeroConf: boolean
-  expectedAmount: number
+  address: string
   bip21: string
+  blindingKey: string
+  expectedAmount: number
+  id: string
+  redeemScript: string
+  timeoutBlockHeight: number
 }
 
 export type ReverseSubmarineSwapResponse = {
+  blindingKey: string
   id: string
   invoice: string
   lockupAddress: string

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,8 +5,6 @@ export const maxBorrowRatio = 400
 export const minMultiplyRatio = 130
 export const maxMultiplyRatio = 330
 
-export const defaultPayout = 0
-
 // marina account IDs
 export const marinaFujiAccountID = 'fuji' // slip13(fuji)
 export const marinaMainAccountID = 'mainAccount' // m/84'/1776'/0'

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -1,12 +1,6 @@
 import { ActivityType, Asset, Contract, ContractState, Oracle } from './types'
 import Decimal from 'decimal.js'
-import {
-  assetPair,
-  defaultPayout,
-  expirationSeconds,
-  expirationTimeout,
-  minDustLimit,
-} from './constants'
+import { expirationSeconds, minDustLimit } from './constants'
 import { getNetwork, getMainAccountXPubKey } from './marina'
 import {
   updateContractOnStorage,
@@ -106,7 +100,6 @@ export const coinToContract = async (
       expirationDate: getContractExpirationDate(Math.floor(createdAt / 1000)),
       network: await getNetwork(),
       oracles: [oraclePublicKey],
-      payout: defaultPayout,
       priceLevel: hex64LEToNumber(priceLevel),
       synthetic: {
         ...synthetic,
@@ -115,7 +108,6 @@ export const coinToContract = async (
       txid: coin.txid,
       vout: coin.vout,
     }
-    contract.payoutAmount = getContractPayoutAmount(contract)
     return contract
   }
 }
@@ -188,20 +180,6 @@ export const getCollateralQuantity = (
     .toNumber()
   const collateralAmount = toSatoshis(colUnits, collateral.precision)
   return collateralAmount
-}
-
-// get contract payout
-export const getContractPayoutAmount = (
-  contract: Contract,
-  quantity?: number,
-): number => {
-  if (defaultPayout === 0) return 0
-  const collateralAmount = quantity || contract.collateral.quantity
-  if (!collateralAmount) return 0
-  const payout = contract.payout || defaultPayout
-  return Decimal.ceil(
-    Decimal.mul(collateralAmount, payout).div(100).add(minDustLimit),
-  ).toNumber()
 }
 
 // get contract price level

--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -175,6 +175,7 @@ export async function prepareBorrowTxWithClaimTx(
     contract,
     oracle,
   )
+
   updater
     .addInputs([
       {
@@ -472,20 +473,13 @@ export async function prepareRedeemTx(
 
   // add synthetic change if any
   if (syntheticChangeAmount > 0) {
-    const borrowChangeAddress = await getNextChangeAddress()
+    const syntheticChangeAddress = await getNextChangeAddress()
     tx.withRecipient(
-      borrowChangeAddress.confidentialAddress,
+      syntheticChangeAddress.confidentialAddress,
       syntheticChangeAmount,
       synthetic.id,
       0,
     )
-  } else if (swapAddress) {
-    // in a redeem, some inputs (if not all) are confidential.
-    // in the case of a redeem to lightning, if we don't have any change
-    // all outputs will be unconfidential, which would break the protocol.
-    // by adding a confidential op_return with value 0 fixes it.
-    const blindingKey = randomBytes(33).toString('hex')
-    tx.withOpReturn(0, collateral.id, [], blindingKey, 0)
   }
 
   // pay fees

--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -43,7 +43,6 @@ import {
 } from './marina'
 import * as ecc from 'tiny-secp256k1'
 import { Contract as IonioContract } from '@ionio-lang/ionio'
-import { randomBytes } from 'crypto'
 import { selectCoins } from './selection'
 import { Network } from 'liquidjs-lib/src/networks'
 import { artifact } from './artifact'
@@ -426,12 +425,12 @@ export async function prepareRedeemTx(
 
   const unblindData = blindingData
     ? {
-        value: blindingData.value.toString(),
         asset: AssetHash.fromHex(blindingData.asset).bytesWithoutPrefix,
         assetBlindingFactor: Buffer.from(
           blindingData.assetBlindingFactor,
           'hex',
         ),
+        value: blindingData.value.toString(),
         valueBlindingFactor: Buffer.from(
           blindingData.valueBlindingFactor,
           'hex',

--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -400,8 +400,8 @@ export async function prepareRedeemTx(
         'Wait for confirmations or try to reload the wallet and try again.',
     )
 
-  const utxos = await getMainAccountCoins()
   // validate we have sufficient synthetic funds
+  const utxos = await getMainAccountCoins()
   const syntheticUtxos = selectCoins(utxos, synthetic.id, synthetic.quantity)
   if (syntheticUtxos.length === 0) throw new Error('Not enough fuji funds')
 

--- a/lib/offers.ts
+++ b/lib/offers.ts
@@ -18,7 +18,6 @@ export function populateOffer(
     id: offer.id,
     collateral,
     oracles: oraclePubkeys,
-    payout: 0,
     synthetic,
     isAvailable: true,
   }

--- a/lib/swaps.ts
+++ b/lib/swaps.ts
@@ -3,10 +3,7 @@ import bolt11 from 'bolt11'
 import { address, crypto, script, payments } from 'liquidjs-lib'
 import { fromSatoshis } from 'lib/utils'
 import { feeAmount, swapFeeAmount } from './constants'
-import Boltz, {
-  ReverseSubmarineSwapResponse,
-  SubmarineSwapResponse,
-} from './boltz'
+import Boltz, { SubmarineSwapResponse } from './boltz'
 import { randomBytes } from 'crypto'
 import Decimal from 'decimal.js'
 import { NetworkString } from 'marina-provider'
@@ -116,12 +113,16 @@ export const createSubmarineSwap = async (
   const boltz = new Boltz(network)
 
   // create submarine swap
-  const response: SubmarineSwapResponse = await boltz.createSubmarineSwap({
+  const {
+    address,
+    expectedAmount,
+    id,
+    blindingKey,
+    redeemScript,
+  }: SubmarineSwapResponse = await boltz.createSubmarineSwap({
     invoice,
     refundPublicKey,
   })
-  console.log('response', response)
-  const { address, expectedAmount, id, blindingKey, redeemScript } = response
 
   const submarineSwap: SubmarineSwap = {
     address,
@@ -233,14 +234,6 @@ export const createReverseSubmarineSwap = async (
   const claimPublicKey = p.pubkey!.toString('hex')
 
   // create reverse submarine swap
-  const response = await boltz.createReverseSubmarineSwap({
-    claimPublicKey,
-    onchainAmount,
-    preimageHash,
-  })
-
-  console.log('response', response)
-
   const {
     blindingKey,
     id,
@@ -248,7 +241,11 @@ export const createReverseSubmarineSwap = async (
     lockupAddress,
     redeemScript,
     timeoutBlockHeight,
-  } = response
+  } = await boltz.createReverseSubmarineSwap({
+    claimPublicKey,
+    onchainAmount,
+    preimageHash,
+  })
 
   const reverseSwap: ReverseSwap = {
     blindingKey,

--- a/lib/swaps.ts
+++ b/lib/swaps.ts
@@ -65,7 +65,9 @@ export const getInvoiceExpireDate = (invoice: string): number => {
 
 export interface SubmarineSwap {
   address: string
+  blindingKey: string
   expectedAmount: number
+  id: string
   redeemScript: string
 }
 
@@ -114,15 +116,18 @@ export const createSubmarineSwap = async (
   const boltz = new Boltz(network)
 
   // create submarine swap
-  const { expectedAmount, address, redeemScript }: SubmarineSwapResponse =
-    await boltz.createSubmarineSwap({
-      invoice,
-      refundPublicKey,
-    })
+  const response: SubmarineSwapResponse = await boltz.createSubmarineSwap({
+    invoice,
+    refundPublicKey,
+  })
+  console.log('response', response)
+  const { address, expectedAmount, id, blindingKey, redeemScript } = response
 
   const submarineSwap: SubmarineSwap = {
     address,
+    blindingKey,
     expectedAmount,
+    id,
     redeemScript,
   }
   if (isValidSubmarineSwap(redeemScript, refundPublicKey)) return submarineSwap
@@ -131,6 +136,7 @@ export const createSubmarineSwap = async (
 // REVERSE SUBMARINE SWAPS (Lightning => LBTC)
 
 export interface ReverseSwap {
+  blindingKey: string
   claimPublicKey: string
   id: string
   invoice: string
@@ -227,19 +233,25 @@ export const createReverseSubmarineSwap = async (
   const claimPublicKey = p.pubkey!.toString('hex')
 
   // create reverse submarine swap
-  const {
-    id,
-    invoice,
-    lockupAddress,
-    redeemScript,
-    timeoutBlockHeight,
-  }: ReverseSubmarineSwapResponse = await boltz.createReverseSubmarineSwap({
+  const response = await boltz.createReverseSubmarineSwap({
     claimPublicKey,
     onchainAmount,
     preimageHash,
   })
 
-  const reverseSwap = {
+  console.log('response', response)
+
+  const {
+    blindingKey,
+    id,
+    invoice,
+    lockupAddress,
+    redeemScript,
+    timeoutBlockHeight,
+  } = response
+
+  const reverseSwap: ReverseSwap = {
+    blindingKey,
     claimPublicKey,
     id,
     invoice,

--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -17,10 +17,10 @@ export const EnabledTasks: Record<string, boolean> = {
 }
 
 export const LightningEnabledTasks: Record<string, boolean> = {
-  [Tasks.Borrow]: false,
+  [Tasks.Borrow]: true,
   [Tasks.Exchange]: false,
   [Tasks.Multiply]: false,
-  [Tasks.Redeem]: false,
+  [Tasks.Redeem]: true,
   [Tasks.Renew]: false,
   [Tasks.Topup]: false,
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -103,8 +103,6 @@ export interface Contract {
   expirationDate?: number
   network?: string
   oracles: string[]
-  payout: number
-  payoutAmount?: number
   priceLevel?: number
   state?: ContractState
   synthetic: Asset
@@ -123,7 +121,6 @@ export interface Offer {
   id: string
   collateral: Asset
   oracles: string[]
-  payout: number
   synthetic: Asset
   isAvailable: boolean
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ionio-lang/ionio": "^0.3.0",
     "@types/tiny-secp256k1": "^2.0.1",
     "@vulpemventures/secp256k1-zkp": "^2.1.1",
+    "bech32": "^2.0.0",
     "bip32": "^3.0.1",
     "bolt11": "^1.4.0",
     "bs58check": "^3.0.1",

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -179,7 +179,6 @@ const BorrowParams: NextPage = () => {
       value: parseInt(value, 10),
       valueBlindingFactor: valueBlindingFactor.toString('hex'),
     }
-    console.log('utxo', u)
 
     // clear invoice expiration timeout
     clearTimeout(invoiceExpirationTimeout)
@@ -201,9 +200,10 @@ const BorrowParams: NextPage = () => {
     preparedTx: PreparedBorrowTx,
   ) => {
     if (!network) return
-    console.log('pset', pset)
+
     // change message to user
     setStage(ModalStages.NeedsFinishing)
+
     // broadcast transaction
     const rawHex = finalizeTx(pset)
     console.log('rawHex', rawHex)

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -58,7 +58,7 @@ const BorrowParams: NextPage = () => {
     useContext(WalletContext)
   const { weblnCanEnable, weblnProvider, weblnProviderName } =
     useContext(WeblnContext)
-  const { config } = useContext(ConfigContext)
+  const { config, reloadConfig } = useContext(ConfigContext)
   const { loading, newContract, reloadContracts, resetContracts } =
     useContext(ContractsContext)
 
@@ -220,6 +220,7 @@ const BorrowParams: NextPage = () => {
       )
       .then(() => {
         markContractConfirmed(newContract)
+        reloadConfig()
         reloadContracts()
       })
 

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -1,10 +1,10 @@
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import Borrow from 'components/borrow'
 import SomeError, { SomethingWentWrong } from 'components/layout/error'
 import Offers from 'components/offers'
-import { Asset, Contract, Offer, Outcome } from 'lib/types'
+import { Asset, Contract, Outcome } from 'lib/types'
 import Spinner from 'components/spinner'
 import { ContractsContext } from 'components/providers/contracts'
 import Channel from 'components/channel'
@@ -58,9 +58,8 @@ const BorrowParams: NextPage = () => {
     useContext(WalletContext)
   const { weblnCanEnable, weblnProvider, weblnProviderName } =
     useContext(WeblnContext)
-  const { config, reloadConfig } = useContext(ConfigContext)
-  const { loading, newContract, reloadContracts, resetContracts } =
-    useContext(ContractsContext)
+  const { config } = useContext(ConfigContext)
+  const { loading, newContract, resetContracts } = useContext(ContractsContext)
 
   const [data, setData] = useState('')
   const [result, setResult] = useState('')
@@ -220,8 +219,6 @@ const BorrowParams: NextPage = () => {
       )
       .then(() => {
         markContractConfirmed(newContract)
-        reloadConfig()
-        reloadContracts()
       })
 
     // show success
@@ -354,7 +351,6 @@ const BorrowParams: NextPage = () => {
   switch (params.length) {
     case 1:
       // /borrow/fUSD => show list of offers filtered by ticker
-      resetContracts()
       return <Offers offers={offers} ticker={params[0]} />
     case 2:
       // /borrow/fUSD/L-BTC => show form to borrow synthetic

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -59,7 +59,8 @@ const BorrowParams: NextPage = () => {
   const { weblnCanEnable, weblnProvider, weblnProviderName } =
     useContext(WeblnContext)
   const { config } = useContext(ConfigContext)
-  const { loading, newContract, resetContracts } = useContext(ContractsContext)
+  const { loading, newContract, reloadContracts, resetContracts } =
+    useContext(ContractsContext)
 
   const [data, setData] = useState('')
   const [result, setResult] = useState('')
@@ -219,6 +220,7 @@ const BorrowParams: NextPage = () => {
       )
       .then(() => {
         markContractConfirmed(newContract)
+        reloadContracts()
       })
 
     // show success

--- a/pages/borrow/index.tsx
+++ b/pages/borrow/index.tsx
@@ -10,11 +10,9 @@ import { ConfigContext } from 'components/providers/config'
 
 const Borrow: NextPage = () => {
   const { config } = useContext(ConfigContext)
-  const { loading, resetContracts } = useContext(ContractsContext)
+  const { loading } = useContext(ContractsContext)
 
   const { offers } = config
-
-  resetContracts()
 
   if (!EnabledTasks[Tasks.Borrow]) return <NotAllowed />
   if (loading) return <Spinner />

--- a/pages/contracts/[txid]/close/channel.tsx
+++ b/pages/contracts/[txid]/close/channel.tsx
@@ -23,7 +23,7 @@ const ContractRedeemChannel: NextPage = () => {
   const { txid } = router.query
 
   useEffect(() => {
-    if (txid && typeof txid === 'string') {
+    if (txid && typeof txid === 'string' && network) {
       getContract(txid, assets, network).then((contract) => {
         if (contract) setNewContract(contract)
         setIsLoading(false)

--- a/pages/contracts/[txid]/close/lightning.tsx
+++ b/pages/contracts/[txid]/close/lightning.tsx
@@ -42,6 +42,7 @@ const ContractRedeemLightning: NextPage = () => {
     // select coins and prepare redeem transaction
     setStage(ModalStages.NeedsCoins)
     const tx = await prepareRedeemTx(newContract, network, swapAddress)
+    console.log('tx.pset', tx.pset)
 
     // ask user to sign transaction
     setStage(ModalStages.NeedsConfirmation)

--- a/pages/contracts/[txid]/close/lightning.tsx
+++ b/pages/contracts/[txid]/close/lightning.tsx
@@ -42,7 +42,6 @@ const ContractRedeemLightning: NextPage = () => {
     // select coins and prepare redeem transaction
     setStage(ModalStages.NeedsCoins)
     const tx = await prepareRedeemTx(newContract, network, swapAddress)
-    console.log('tx.pset', tx.pset)
 
     // ask user to sign transaction
     setStage(ModalStages.NeedsConfirmation)

--- a/pages/contracts/[txid]/close/lightning.tsx
+++ b/pages/contracts/[txid]/close/lightning.tsx
@@ -39,7 +39,7 @@ const ContractRedeemLightning: NextPage = () => {
   const amount = quantity - payoutAmount
 
   const proceedWithRedeem = async (swapAddress?: string) => {
-    if (!marina) return
+    if (!marina || !network) return
 
     // select coins and prepare redeem transaction
     setStage(ModalStages.NeedsCoins)
@@ -72,7 +72,7 @@ const ContractRedeemLightning: NextPage = () => {
   }
 
   const handleInvoice = async (invoice?: string): Promise<void> => {
-    if (!marina) return
+    if (!marina || !network) return
     if (!invoice || typeof invoice !== 'string')
       return openModal(ModalIds.Invoice)
     closeModal(ModalIds.Invoice)

--- a/pages/contracts/[txid]/close/lightning.tsx
+++ b/pages/contracts/[txid]/close/lightning.tsx
@@ -35,8 +35,6 @@ const ContractRedeemLightning: NextPage = () => {
   if (!newContract) return <SomeError>Contract not found</SomeError>
 
   const quantity = newContract.collateral.quantity
-  const payoutAmount = newContract.payoutAmount || 0
-  const amount = quantity - payoutAmount
 
   const proceedWithRedeem = async (swapAddress?: string) => {
     if (!marina || !network) return
@@ -90,7 +88,7 @@ const ContractRedeemLightning: NextPage = () => {
       )
       if (!boltzSwap) throw new Error('Error creating swap')
       const { address, expectedAmount } = boltzSwap
-      if (expectedAmount > amount)
+      if (expectedAmount > quantity)
         throw new Error('Expected amount higher then collateral amount')
       proceedWithRedeem(address)
     } catch (error) {

--- a/pages/contracts/[txid]/close/liquid.tsx
+++ b/pages/contracts/[txid]/close/liquid.tsx
@@ -33,6 +33,7 @@ const ContractRedeemLiquid: NextPage = () => {
   if (!newContract) return <SomeError>Contract not found</SomeError>
 
   async function handleMarina(): Promise<void> {
+    if (!network) return
     openModal(ModalIds.Redeem)
     try {
       // select coins and prepare redeem transaction

--- a/pages/contracts/[txid]/topup/index.tsx
+++ b/pages/contracts/[txid]/topup/index.tsx
@@ -25,7 +25,7 @@ const ContractTopup: NextPage = () => {
   const { txid } = router.query
 
   useEffect(() => {
-    if (txid && typeof txid === 'string') {
+    if (txid && typeof txid === 'string' && network) {
       getContract(txid, assets, network).then((contract) => {
         if (contract) {
           if (!newContract) setNewContract(contract)

--- a/pages/contracts/[txid]/topup/lightning.tsx
+++ b/pages/contracts/[txid]/topup/lightning.tsx
@@ -50,7 +50,7 @@ const ContractTopupLightning: NextPage = () => {
     useContext(WalletContext)
   const { weblnProviderName } = useContext(WeblnContext)
   const { config } = useContext(ConfigContext)
-  const { newContract, oldContract, reloadContracts, resetContracts } =
+  const { newContract, oldContract, resetContracts } =
     useContext(ContractsContext)
 
   const [data, setData] = useState('')
@@ -248,7 +248,6 @@ const ContractTopupLightning: NextPage = () => {
           )
           .then(() => {
             markContractConfirmed(newContract)
-            reloadContracts()
           })
 
         // mark old contract as topup
@@ -258,7 +257,6 @@ const ContractTopupLightning: NextPage = () => {
         setData(newContract.txid)
         setResult('success')
         setStage(ModalStages.ShowResult)
-        reloadContracts()
       }
     } catch (error) {
       setData(extractError(error))

--- a/pages/contracts/[txid]/topup/lightning.tsx
+++ b/pages/contracts/[txid]/topup/lightning.tsx
@@ -76,7 +76,7 @@ const ContractTopupLightning: NextPage = () => {
   if (!newContract) throw new Error('Missing contract')
 
   const handleInvoice = async (): Promise<void> => {
-    if (!marina) return
+    if (!marina || !network) return
     openModal(ModalIds.InvoiceDeposit)
     setStage(ModalStages.NeedsInvoice)
     try {

--- a/pages/contracts/[txid]/topup/lightning.tsx
+++ b/pages/contracts/[txid]/topup/lightning.tsx
@@ -50,7 +50,7 @@ const ContractTopupLightning: NextPage = () => {
     useContext(WalletContext)
   const { weblnProviderName } = useContext(WeblnContext)
   const { config } = useContext(ConfigContext)
-  const { newContract, oldContract, resetContracts } =
+  const { newContract, oldContract, reloadContracts, resetContracts } =
     useContext(ContractsContext)
 
   const [data, setData] = useState('')
@@ -248,6 +248,7 @@ const ContractTopupLightning: NextPage = () => {
           )
           .then(() => {
             markContractConfirmed(newContract)
+            reloadContracts()
           })
 
         // mark old contract as topup

--- a/pages/contracts/[txid]/topup/liquid.tsx
+++ b/pages/contracts/[txid]/topup/liquid.tsx
@@ -32,7 +32,7 @@ const ContractTopupLiquid: NextPage = () => {
   const { chainSource, marina, network, updateBalances } =
     useContext(WalletContext)
   const { config } = useContext(ConfigContext)
-  const { newContract, oldContract, resetContracts } =
+  const { newContract, oldContract, reloadContracts, resetContracts } =
     useContext(ContractsContext)
 
   const [data, setData] = useState('')
@@ -134,6 +134,7 @@ const ContractTopupLiquid: NextPage = () => {
         )
         .then(() => {
           markContractConfirmed(newContract)
+          reloadContracts()
         })
 
       // mark old contract as topup

--- a/pages/contracts/[txid]/topup/liquid.tsx
+++ b/pages/contracts/[txid]/topup/liquid.tsx
@@ -61,7 +61,7 @@ const ContractTopupLiquid: NextPage = () => {
     newContract.collateral.quantity - oldContract.collateral.quantity
 
   const handleMarina = async (): Promise<void> => {
-    if (!marina) return
+    if (!marina || !network) return
     openModal(ModalIds.MarinaDeposit)
     setStage(ModalStages.NeedsCoins)
     try {

--- a/pages/contracts/[txid]/topup/liquid.tsx
+++ b/pages/contracts/[txid]/topup/liquid.tsx
@@ -32,7 +32,7 @@ const ContractTopupLiquid: NextPage = () => {
   const { chainSource, marina, network, updateBalances } =
     useContext(WalletContext)
   const { config } = useContext(ConfigContext)
-  const { newContract, oldContract, reloadContracts, resetContracts } =
+  const { newContract, oldContract, resetContracts } =
     useContext(ContractsContext)
 
   const [data, setData] = useState('')
@@ -134,7 +134,6 @@ const ContractTopupLiquid: NextPage = () => {
         )
         .then(() => {
           markContractConfirmed(newContract)
-          reloadContracts()
         })
 
       // mark old contract as topup
@@ -144,7 +143,6 @@ const ContractTopupLiquid: NextPage = () => {
       setData(newContract.txid)
       setResult(Outcome.Success)
       setStage(ModalStages.ShowResult)
-      reloadContracts()
     } catch (error) {
       setData(extractError(error))
       setResult(Outcome.Failure)


### PR DESCRIPTION
bug fixes:
- after mint, modal with success was being closed immediately due to re-render of component caused by reloadContracts and reloadConfig
- reload config on utxo spent/earn to update minted quantity
- if marina was on 'testnet' when loading the app, assets from 'mainnet' would appear in dashboard due to a race condition
- remove payout from contracts
- assets list now uses 'loading' from config instead of contract provider
- refactor invoice modal to support lnurl and ln addresses
- use boltz's confidential transactions on swaps
- enable Lightning for borrow and redeem

@tiero please review