### PR TITLE
add Playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: yarn
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, dev ]
 jobs:
   test:
     timeout-minutes: 60
@@ -17,11 +17,7 @@ jobs:
       run: yarn
     - name: Install Playwright Browsers
       run: yarn playwright install --with-deps
+    - name: Download testing extensions
+      run: yarn test:init
     - name: Run Playwright tests
-      run: yarn playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      run: xvfb-run npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ yarn-error.log*
 # dev files
 .env.development
 .vscode
+/test-results/
+/playwright-report/
+/playwright/.cache/
+tests/marina

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ To build the Fuji App for production, you can use the following command:
 yarn build
 ```
 
+## 🧪 Test
+
+The app is using [Playwright](https://playwright.dev/) to test UI interactions. Tests should be located in the `tests` folder with the `.spec.ts` extension.
+
+### Downloads the testing browser extensions
+
+Fuji App needs some browser extension wallets to be installed. `test:init` script downloads them for you.  The extensions are downloaded in the `tests` folder and should not be committed.
+
+```bash
+# DL the extensions for testing, only needed once
+yarn test:init
+```
+
+### Run the tests
+
+```bash
+yarn test
+```
+
 ## 📝 License
 The Fuji App is licensed under the [MIT License](LICENSE.md)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "prettier": "npx prettier --check pages/ components/ lib/",
     "prettier:fix": "npx prettier --write pages/ components/ lib/",
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:init": "bash ./scripts/getmarina.sh"
   },
   "dependencies": {
     "@ionio-lang/ionio": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "prettier": "npx prettier --check pages/ components/ lib/",
-    "prettier:fix": "npx prettier --write pages/ components/ lib/"
+    "prettier:fix": "npx prettier --write pages/ components/ lib/",
+    "test": "playwright test"
   },
   "dependencies": {
     "@ionio-lang/ionio": "^0.3.0",
@@ -36,11 +37,13 @@
     "ws-electrumx-client": "^1.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.36.2",
     "@types/file-saver": "^2.0.5",
     "@types/node": "17.0.23",
     "@types/react": "17.0.43",
     "@types/react-dom": "17.0.14",
     "@types/styled-jsx": "^3.4.4",
+    "bip39": "^3.1.0",
     "buffer": "^6.0.3",
     "eslint": "8.12.0",
     "eslint-config-next": "12.1.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,10 +33,6 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
       name: 'Google Chrome',
       use: { ...devices['Desktop Chrome'], channel: 'chrome' }, // or 'chrome-beta'
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' }, // or 'chrome-beta'
+    },
+  ],
+
+  webServer: {
+    command: 'yarn dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/scripts/getmarina.sh
+++ b/scripts/getmarina.sh
@@ -1,0 +1,3 @@
+mkdir tests/marina
+wget https://github.com/vulpemventures/marina/releases/download/v0.5.2/marina-v3-0.5.2.zip -P tests/marina
+unzip tests/marina/marina-v3-0.5.2.zip -d tests/marina

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, makeOnboardingRestore, FUJI_APP_LOCAL_URL, switchToTestnetNetwork, PASSWORD } from './utils';
+
+test('has title', async ({ page }) => {
+  await page.goto(FUJI_APP_LOCAL_URL);
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/App - Fuji Money/);
+});
+
+test('should connect to the extension and mint fujis', async ({ page, extensionId, context }) => {
+  await makeOnboardingRestore(page, extensionId);
+  await switchToTestnetNetwork(page, extensionId);
+  await page.goto(FUJI_APP_LOCAL_URL);
+  await page.waitForSelector('text=Mint')
+
+  // connect Marina
+  await page.getByRole('button', { name: 'Connect Wallet' }).click();
+  // click on first article (Marina)
+  await page.getByRole('article').first().click();
+  const marinaPopup = await context.waitForEvent('page');
+  await marinaPopup.getByRole('button', { name: 'Connect' }).click()
+  
+  const marinaPopupCreateAccount = await context.waitForEvent('page');
+  await marinaPopupCreateAccount.getByRole('button', { name: 'Accept' }).click()
+  // fill password
+  await marinaPopupCreateAccount.getByPlaceholder('Password').fill(PASSWORD);
+  await marinaPopupCreateAccount.getByRole('button', { name: 'Unlock' }).click()
+
+  await page.waitForSelector('text=Mint')
+
+  // go to mint
+  await page.getByRole('button', { name: 'Mint' }).click();
+  // expect to be on mint page
+  await page.waitForSelector('FUSD');
+  expect(page.url()).toBe(`${FUJI_APP_LOCAL_URL}/borrow/FUSD`);
+
+  await page.getByRole('button', { name: 'Mint' }).click();
+  await page.getByPlaceholder('0.00').fill('25');
+  await page.getByRole('button', { name: 'Proceed to deposit' }).click();
+});

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,40 +1,6 @@
-import { test, expect, makeOnboardingRestore, FUJI_APP_LOCAL_URL, switchToTestnetNetwork, PASSWORD } from './utils';
+import { test, expect } from '@playwright/test';
 
-test('has title', async ({ page }) => {
-  await page.goto(FUJI_APP_LOCAL_URL);
-
-  // Expect a title "to contain" a substring.
+test('has "App - Fuji Money" title', async ({ page }) => {
+  await page.goto('/');
   await expect(page).toHaveTitle(/App - Fuji Money/);
-});
-
-test('should connect to the extension and mint fujis', async ({ page, extensionId, context }) => {
-  await makeOnboardingRestore(page, extensionId);
-  await switchToTestnetNetwork(page, extensionId);
-  await page.goto(FUJI_APP_LOCAL_URL);
-  await page.waitForSelector('text=Mint')
-
-  // connect Marina
-  await page.getByRole('button', { name: 'Connect Wallet' }).click();
-  // click on first article (Marina)
-  await page.getByRole('article').first().click();
-  const marinaPopup = await context.waitForEvent('page');
-  await marinaPopup.getByRole('button', { name: 'Connect' }).click()
-  
-  const marinaPopupCreateAccount = await context.waitForEvent('page');
-  await marinaPopupCreateAccount.getByRole('button', { name: 'Accept' }).click()
-  // fill password
-  await marinaPopupCreateAccount.getByPlaceholder('Password').fill(PASSWORD);
-  await marinaPopupCreateAccount.getByRole('button', { name: 'Unlock' }).click()
-
-  await page.waitForSelector('text=Mint')
-
-  // go to mint
-  await page.getByRole('button', { name: 'Mint' }).click();
-  // expect to be on mint page
-  await page.waitForSelector('FUSD');
-  expect(page.url()).toBe(`${FUJI_APP_LOCAL_URL}/borrow/FUSD`);
-
-  await page.getByRole('button', { name: 'Mint' }).click();
-  await page.getByPlaceholder('0.00').fill('25');
-  await page.getByRole('button', { name: 'Proceed to deposit' }).click();
 });

--- a/tests/mint.spec.ts
+++ b/tests/mint.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect, makeOnboardingRestore, switchToTestnetNetwork, PASSWORD } from './utils';
+
+// this test does not go through the entire mint flow (waiting for a regtest config to do this)
+// it only checks that the mint page is accessible 
+test('connect marina & use the mint page', async ({ page, extensionId, context }) => {
+  await makeOnboardingRestore(page, extensionId);
+  await switchToTestnetNetwork(page, extensionId);
+  await page.goto('/');
+  await page.waitForSelector('text=Mint')
+
+  // connect Marina
+  await page.getByRole('button', { name: 'Connect Wallet' }).click();
+  await page.getByRole('article').first().click(); // first is marina
+  const marinaPopup = await context.waitForEvent('page');
+  await marinaPopup.getByRole('button', { name: 'Connect' }).click()
+  
+  const marinaPopupCreateAccount = await context.waitForEvent('page');
+  await marinaPopupCreateAccount.getByRole('button', { name: 'Accept' }).click()
+  await marinaPopupCreateAccount.getByPlaceholder('Password').fill(PASSWORD);
+  await marinaPopupCreateAccount.getByRole('button', { name: 'Unlock' }).click()
+
+  await page.waitForSelector('text=Mint')
+
+  // go to mint and try to fill some random values
+  await page.getByRole('button', { name: 'Mint' }).click();
+  await page.waitForSelector('text=Collateral Asset')
+  await page.getByRole('button', { name: 'Mint' }).click();
+  await page.waitForSelector('text=Borrow')
+  await page.getByPlaceholder('0.00').fill('25');
+
+  // expect to find the proceed to deposit button disabled
+  await expect(page.getByRole('button', { name: 'Proceed to Deposit' })).toBeDisabled();
+  await expect(page.getByText('not enough funds')).toBeVisible();
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,8 +3,6 @@ import { test as basePlaywrightTest, chromium } from '@playwright/test';
 import { generateMnemonic } from 'bip39';
 import path from 'path';
 
-export const FUJI_APP_LOCAL_URL = 'http://localhost:3000';
-
 export const test = basePlaywrightTest.extend<{
   context: BrowserContext;
   extensionId: string;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,74 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { test as basePlaywrightTest, chromium } from '@playwright/test';
+import { generateMnemonic } from 'bip39';
+import path from 'path';
+
+export const FUJI_APP_LOCAL_URL = 'http://localhost:3000';
+
+export const test = basePlaywrightTest.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+    // eslint-disable-next-line no-empty-pattern
+    context: async ({ }, use) => {
+        const pathToExtension = path.join(__dirname, 'marina');
+        const context = await chromium.launchPersistentContext('', {
+            headless: false,
+            args: [
+                `--disable-extensions-except=${pathToExtension}`,
+                `--load-extension=${pathToExtension}`,
+            ],
+        });
+        await use(context);
+        await context.close();
+    },
+    extensionId: async ({ context }, use) => {
+        let extensionID = '';
+        if (process.env.MANIFEST_VERSION === 'v2') {
+            let [backgroundPage] = context.backgroundPages()
+            if (!backgroundPage) backgroundPage = await context.waitForEvent('backgroundpage')
+            extensionID = backgroundPage.url().split('/')[2]
+        } else {
+            let [serviceWorker] = context.serviceWorkers()
+            if (!serviceWorker) serviceWorker = await context.waitForEvent('serviceworker')
+            extensionID = serviceWorker.url().split('/')[2]
+        }
+        await use(extensionID);
+    },
+});
+
+export const PASSWORD = 'passwordsupersecretonlyfortesting';
+
+export const marinaURL = (extensionID: string, path: string) =>
+  `chrome-extension://${extensionID}/${path}`;
+
+export const switchToTestnetNetwork = async (page: Page, extensionID: string) => {
+// go to networks page and switch to regtest
+    await page.goto(marinaURL(extensionID, 'popup.html'));
+    await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await page.waitForSelector('text=Assets');
+    await page.getByAltText('menu icon').click(); // hamburger menu
+    await page.getByText('Settings').click();
+    await page.getByRole('button', { name: 'Networks' }).click();
+    await page.getByRole('button', { name: 'Liquid' }).click(); // by default on Liquid, so the button contains the network name
+    await page.getByText('Testnet').click();
+    // wait some time for the network to switch
+    await page.waitForTimeout(2000);
+}
+
+export const makeOnboardingRestore = async (page: Page, extensionID: string) => {
+  await page.goto(marinaURL(extensionID, 'home.html#initialize/welcome'));
+  await page.getByRole('button', { name: 'Get Started' }).click();
+  await page.getByRole('button', { name: 'Restore' }).click();
+
+  const mnemonic = generateMnemonic();
+  await page.getByRole('textbox', { name: 'mnemonic' }).fill(mnemonic);
+  await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+  await page.getByPlaceholder('Confirm your password').fill(PASSWORD);
+  await page.getByRole('checkbox').check();
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.waitForSelector('text=Your wallet is ready');
+};
+
+export const expect = test.expect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@playwright/test@^1.36.2":
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.36.2.tgz#9edd68a02b0929c5d78d9479a654ceb981dfb592"
+  integrity sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.36.2"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 "@rushstack/eslint-patch@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.8.tgz#be3e914e84eacf16dbebd311c0d0b44aa1174c64"
@@ -509,6 +519,13 @@ bip32@^3.0.1:
     create-hmac "^1.1.7"
     typeforce "^1.11.5"
     wif "^2.0.6"
+
+bip39@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"
+  integrity sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
 
 bip66@^1.1.0:
   version "1.1.5"
@@ -1402,7 +1419,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -2190,6 +2207,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+playwright-core@1.36.2:
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.2.tgz#32382f2d96764c24c65a86ea336cf79721c2e50e"
+  integrity sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==
 
 pngjs@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR adds the [Playwright](https://playwright.dev/) config in order to run UI tests on the app.

* update README
* `yarn test` runs e2e tests on Google Chrome browser
* the browser extensions used during testing should be downloaded using `yarn test:init`.
* add a test for the /mint page (checking if the form is accessible while marina is connected)
* add a CI flow `playwright.yml`

@tiero @easter-monolith please review