### PR TITLE
remove `NEXT_PUBLIC_LIQUIDATOR_PUBKEY` and `NEXT_PUBLIC_FUSD_ASSET_ID`

### DIFF
--- a/components/providers/config.tsx
+++ b/components/providers/config.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   useState,
 } from 'react'
-import { Config, ConfigResponse } from 'lib/types'
+import { Config } from 'lib/types'
 import { WalletContext } from './wallet'
 import { fetchConfig, getBTCvalue } from 'lib/api'
 import { openModal } from 'lib/utils'

--- a/components/providers/config.tsx
+++ b/components/providers/config.tsx
@@ -29,7 +29,12 @@ interface ConfigContextProps {
 }
 
 const emptyArtifact = { contractName: '', constructorInputs: [], functions: [] }
-const emptyConfig = { assets: [], offers: [], oracles: [] }
+const emptyConfig = {
+  assets: [],
+  offers: [],
+  oracles: [],
+  xOnlyTreasuryPublicKey: '',
+}
 
 export const ConfigContext = createContext<ConfigContextProps>({
   artifact: emptyArtifact,
@@ -53,7 +58,7 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     }
 
     // fetch config from factory
-    const config: ConfigResponse = await fetchConfig(network)
+    const config = await fetchConfig(network)
     if (!config) return
 
     // populate oracles with name
@@ -80,7 +85,12 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
       populateOffer(offer, assets, oracles),
     )
 
-    setConfig({ assets, offers, oracles })
+    setConfig({
+      assets,
+      offers,
+      oracles,
+      xOnlyTreasuryPublicKey: config.xOnlyIssuerPublicKey,
+    })
     setLoading(false)
   }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,6 @@
 import { NetworkString } from 'marina-provider'
 import { fetchURL } from './fetch'
-import { Investment, Oracle, Stock } from './types'
+import { ConfigResponse, Investment, Oracle, Stock } from './types'
 import { factoryUrlMainnet, factoryUrlTestnet } from './constants'
 
 export async function fetchInvestments(
@@ -17,8 +17,10 @@ export function getFactoryUrl(network: NetworkString) {
   return network === 'liquid' ? factoryUrlMainnet : factoryUrlTestnet
 }
 
-export async function fetchConfig(network: NetworkString) {
-  return await fetchURL(getFactoryUrl(network) + '/contracts/info')
+export async function fetchConfig(
+  network: NetworkString,
+): Promise<ConfigResponse> {
+  return fetchURL(getFactoryUrl(network) + '/contracts/info')
 }
 
 export const getBTCvalue = async (oracle: Oracle): Promise<number> => {

--- a/lib/assets.ts
+++ b/lib/assets.ts
@@ -1,9 +1,5 @@
 import { NetworkString } from 'marina-provider'
-import {
-  assetExplorerUrlMainnet,
-  assetExplorerUrlTestnet,
-  fUSDAssetId,
-} from './constants'
+import { assetExplorerUrlMainnet, assetExplorerUrlTestnet } from './constants'
 import { Asset, ConfigResponseAsset } from './types'
 import { networks } from 'liquidjs-lib'
 import { fromSatoshis } from './utils'
@@ -54,8 +50,15 @@ const fuji: Asset = {
 }
 
 const assetById: Record<string, Asset> = {
-  [fUSDAssetId]: { ...fuji, precision: 2 }, // mainnet
-  '0d86b2f6a8c3b02a8c7c8836b83a081e68b7e2b4bcdfc58981fc5486f59f7518': fuji, // testnet
+  '0dea022a8a25abb128b42b0f8e98532bc8bd74f8a77dc81251afcc13168acef7': {
+    ...fuji,
+    precision: 2,
+  }, // (FUSD) mainnet
+  '518c0b351f5731f5d40cf6ad444d1c147eda1cdf8c867185c58a526fb02ad806': {
+    ...fuji,
+    precision: 2,
+  }, // (TEST-FUSD) mainnet
+  '0d86b2f6a8c3b02a8c7c8836b83a081e68b7e2b4bcdfc58981fc5486f59f7518': fuji, // (FUSD) testnet
   '6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d': lbtc, // mainnet
   '144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49': lbtc, // testnet
   ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2: usdt, // mainnet

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,14 +14,6 @@ export const marinaLegacyMainAccountID = 'mainAccountLegacy' // m/44'/0'/0'
 
 export const defaultNetwork = 'liquid'
 
-export const treasuryPublicKey =
-  process.env.NEXT_PUBLIC_LIQUIDATOR_PUBKEY ||
-  '03e6fbc4bcd62026a3d5a13ab8fd5b72008ff38907b2ee64de45e25263a418c377'
-
-export const fUSDAssetId =
-  process.env.NEXT_PUBLIC_FUSD_ASSET_ID ||
-  '518c0b351f5731f5d40cf6ad444d1c147eda1cdf8c867185c58a526fb02ad806'
-
 export const factoryUrlMainnet =
   process.env.NEXT_PUBLIC_FACTORY_URL || 'https://dev-factory.fuji.money'
 

--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -3,7 +3,6 @@ import { Utxo, Address, NetworkString } from 'marina-provider'
 import zkpLib from '@vulpemventures/secp256k1-zkp'
 import {
   feeAmount,
-  treasuryPublicKey,
   minDustLimit,
   assetPair,
   expirationTimeout,
@@ -85,6 +84,7 @@ async function getCovenantOutput(
   artifact: Artifact,
   contract: Contract,
   oracle: Oracle,
+  xOnlyTreasuryPublicKey: string,
 ): Promise<{
   contractParams: ContractParams
   covenantOutput: UpdaterOutput
@@ -96,12 +96,11 @@ async function getCovenantOutput(
 
   // set contract params
   const timestamp = Date.now()
-  const treasuryPk = Buffer.from(treasuryPublicKey, 'hex')
   const contractParams: Omit<ContractParams, 'borrowerPublicKey'> = {
     borrowAsset: contract.synthetic.id,
     borrowAmount: contract.synthetic.quantity,
     oraclePublicKey: `0x${oracle.pubkey}`,
-    treasuryPublicKey: `0x${treasuryPk.slice(1).toString('hex')}`,
+    treasuryPublicKey: `0x${xOnlyTreasuryPublicKey}`,
     priceLevel: numberToHex64LE(contract.priceLevel || 0),
     setupTimestamp: numberToHex64LE(timestamp),
     expirationTimeout,
@@ -149,6 +148,7 @@ export async function prepareBorrowTxWithClaimTx(
   utxos: Utxo[],
   redeemScript: string, // must be associated with the first utxo
   oracle: Oracle,
+  xOnlyTreasuryPublicKey: string,
 ): Promise<PreparedBorrowTx> {
   // check for marina
   const marina = await getMarinaProvider()
@@ -176,6 +176,7 @@ export async function prepareBorrowTxWithClaimTx(
     artifact,
     contract,
     oracle,
+    xOnlyTreasuryPublicKey,
   )
 
   updater
@@ -205,6 +206,7 @@ export async function prepareBorrowTx(
   artifact: Artifact,
   contract: Contract,
   oracle: Oracle,
+  xOnlyTreasuryPublicKey: string,
 ): Promise<PreparedBorrowTx> {
   // check for marina
   const marina = await getMarinaProvider()
@@ -241,6 +243,7 @@ export async function prepareBorrowTx(
     artifact,
     contract,
     oracle,
+    xOnlyTreasuryPublicKey,
   )
 
   // add collateral inputs
@@ -512,6 +515,7 @@ export async function prepareTopupTx(
   network: NetworkString,
   collateralUtxos: (Utxo & { redeemScript?: string })[],
   oracle: Oracle,
+  xOnlyTreasuryPublicKey: string,
 ): Promise<PreparedTopupTx> {
   // check for marina
   const marina = await getMarinaProvider()
@@ -552,6 +556,7 @@ export async function prepareTopupTx(
     artifact,
     newContract,
     oracle,
+    xOnlyTreasuryPublicKey,
   )
 
   // find coin for this contract

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -218,4 +218,5 @@ export interface Config {
   assets: Asset[]
   offers: Offer[]
   oracles: Oracle[]
+  xOnlyTreasuryPublicKey: string
 }

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -271,6 +271,7 @@ const BorrowParams: NextPage = () => {
         utxos,
         redeemScript,
         oracles[0],
+        config.xOnlyTreasuryPublicKey,
       )
 
       // propose contract to alpha factory
@@ -340,6 +341,7 @@ const BorrowParams: NextPage = () => {
         artifact,
         newContract,
         oracles[0],
+        config.xOnlyTreasuryPublicKey,
       )
       if (!preparedTx) throw new Error('Unable to prepare Tx')
 

--- a/pages/contracts/[txid]/topup/lightning.tsx
+++ b/pages/contracts/[txid]/topup/lightning.tsx
@@ -175,6 +175,7 @@ const ContractTopupLightning: NextPage = () => {
           network,
           collateralUtxos,
           oracles[0],
+          config.xOnlyTreasuryPublicKey,
         )
 
         // propose contract to alpha factory

--- a/pages/contracts/[txid]/topup/liquid.tsx
+++ b/pages/contracts/[txid]/topup/liquid.tsx
@@ -83,6 +83,7 @@ const ContractTopupLiquid: NextPage = () => {
         network,
         collateralUtxos,
         oracles[0],
+        config.xOnlyTreasuryPublicKey,
       )
       if (!preparedTx) throw new Error('Unable to prepare Tx')
 


### PR DESCRIPTION
This PR removes 2 env variables:

1. NEXT_PUBLIC_FUSD_ASSET_ID: hardcode mainnet asset id with all other synthetic assets (was used only for frontend like icon/precision etc.) ---> **do we really need usdt there?**
2. NEXT_PUBLIC_LIQUIDATOR_PUBKEY: fetch from config 

@tiero please review
