### PR TITLE
add derivationPath used for covenantAddress to contract.json backup file

### DIFF
--- a/lib/covenant.ts
+++ b/lib/covenant.ts
@@ -136,9 +136,10 @@ export interface PreparedBorrowTx {
   borrowerAddress: Address
   changeAddress?: Address
   collateralUtxos: Utxo[]
-  contractParams: ContractParams
   collateralAsset: string
   collateralAmount: number
+  contractParams: ContractParams
+  covenantAddress: Address
   pset: Pset
 }
 
@@ -172,12 +173,8 @@ export async function prepareBorrowTxWithClaimTx(
   const updater = new Updater(pset)
 
   // get covenant
-  const { contractParams, covenantOutput } = await getCovenantOutput(
-    artifact,
-    contract,
-    oracle,
-    xOnlyTreasuryPublicKey,
-  )
+  const { contractParams, covenantOutput, covenantAddress } =
+    await getCovenantOutput(artifact, contract, oracle, xOnlyTreasuryPublicKey)
 
   updater
     .addInputs([
@@ -195,10 +192,11 @@ export async function prepareBorrowTxWithClaimTx(
   return {
     borrowerAddress: await getNextAddress(),
     collateralUtxos: utxos,
-    contractParams,
-    pset: updater.pset,
     collateralAsset: contract.collateral.id,
     collateralAmount: contract.collateral.quantity,
+    covenantAddress,
+    contractParams,
+    pset: updater.pset,
   }
 }
 
@@ -239,12 +237,8 @@ export async function prepareBorrowTx(
   const updater = new Updater(pset)
 
   // get covenant params
-  const { contractParams, covenantOutput } = await getCovenantOutput(
-    artifact,
-    contract,
-    oracle,
-    xOnlyTreasuryPublicKey,
-  )
+  const { contractParams, covenantOutput, covenantAddress } =
+    await getCovenantOutput(artifact, contract, oracle, xOnlyTreasuryPublicKey)
 
   // add collateral inputs
   updater
@@ -285,10 +279,11 @@ export async function prepareBorrowTx(
     borrowerAddress: await getNextAddress(),
     changeAddress,
     collateralUtxos,
-    contractParams,
-    pset: updater.pset,
     collateralAsset: contract.collateral.id,
     collateralAmount: contract.collateral.quantity,
+    contractParams,
+    covenantAddress,
+    pset: updater.pset,
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -100,6 +100,7 @@ export interface Contract {
   confirmed?: boolean
   contractParams?: ContractParams
   createdAt?: number
+  derivationPath?: string
   expirationDate?: number
   network?: string
   oracles: string[]

--- a/pages/borrow/[...params].tsx
+++ b/pages/borrow/[...params].tsx
@@ -222,6 +222,7 @@ const BorrowParams: NextPage = () => {
     // add contractParams to contract
     const { contractParams } = preparedTx
     newContract.contractParams = { ...contractParams }
+    newContract.derivationPath = preparedTx.covenantAddress.derivationPath
     newContract.xPubKey = xPubKey
 
     // add additional fields to contract and save to storage


### PR DESCRIPTION
This PR adds the derivation path used when creating the covenant address to the contract.json backup file.

Useful for when re-creating a restoration file from a contract backup.

@louisinger please review
